### PR TITLE
Implemented 'stop_hidden' configuration option for applications.

### DIFF
--- a/data/rc.xml
+++ b/data/rc.xml
@@ -732,6 +732,13 @@
     <fullscreen>yes</fullscreen>
     # make the window in fullscreen mode when it appears
 
+    <stop_hidden>process</stop_hidden>
+    # stop the application when it hides in order to minimize CPU usage
+    # and power consumption
+    #   'no'      - do not stop application when it hides (default value)
+    #   'process' - stop just the process the window belongs to
+    #   'group'   - stop whole process group the application belongs to
+
     <maximized>true</maximized>
     # 'Horizontal', 'Vertical' or boolean (yes/no)
   </application>

--- a/data/rc.xsd
+++ b/data/rc.xsd
@@ -254,6 +254,7 @@
             <xsd:element minOccurs="0" name="skip_pager" type="ob:bool"/>
             <xsd:element minOccurs="0" name="skip_taskbar" type="ob:bool"/>
             <xsd:element minOccurs="0" name="fullscreen" type="ob:bool"/>
+            <xsd:element minOccurs="0" name="stop_hidden" type="ob:stop_mode"/>
             <xsd:element minOccurs="0" name="maximized" type="ob:maximization"/>
         </xsd:all>
         <!-- at least one of these must be present -->
@@ -483,6 +484,13 @@
             <xsd:enumeration value="BottomLeft"/>
             <xsd:enumeration value="Left"/>
             <xsd:enumeration value="Floating"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="stop_mode">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="no"/>
+            <xsd:enumeration value="process"/>
+            <xsd:enumeration value="group"/>
         </xsd:restriction>
     </xsd:simpleType>
     <xsd:simpleType name="keyname">

--- a/doc/rc-mouse-focus.xml
+++ b/doc/rc-mouse-focus.xml
@@ -625,6 +625,13 @@
     <fullscreen>yes</fullscreen>
     # make the window in fullscreen mode when it appears
 
+    <stop_hidden>process</stop_hidden>
+    # stop the application when it hides in order to minimize CPU usage
+    # and power consumption
+    #   'no'      - do not stop application when it hides (default value)
+    #   'process' - stop just the process the window belongs to
+    #   'group'   - stop whole process group the application belongs to
+
     <maximized>true</maximized>
     # 'Horizontal', 'Vertical' or boolean (yes/no)
   </application>

--- a/openbox/client.h
+++ b/openbox/client.h
@@ -69,6 +69,14 @@ typedef enum
     OB_CLIENT_FUNC_UNDECORATE = 1 << 9  /*!< Allow to be undecorated */
 } ObFunctions;
 
+/*! The way to stop client when it hides */
+typedef enum
+{
+    OB_CLIENT_STOP_MODE_NONE,    /*!< Do not stop client */
+    OB_CLIENT_STOP_MODE_PROCESS, /*!< Stop the client process only */
+    OB_CLIENT_STOP_MODE_GROUP,   /*!< Stop process group the client belongs to */
+} ObClientStopMode;
+
 struct _ObClient
 {
     ObWindow obwin;
@@ -272,6 +280,8 @@ struct _ObClient
     gboolean skip_pager;
     /*! The window should not be displayed by taskbars */
     gboolean skip_taskbar;
+    /*! How to stop the process when it hides or iconifies */
+    ObClientStopMode stop_hidden;
     /*! The window is a 'fullscreen' window, and should be on top of all
       others */
     gboolean fullscreen;
@@ -547,6 +557,12 @@ void client_close(ObClient *self);
 
 /*! Kill the client off violently */
 void client_kill(ObClient *self);
+
+/*! Stop the client process when all its windows are hidded */
+void client_stop_hidden(ObClient *self);
+
+/*! Continue executing the client process when one of its windows appears */
+void client_continue_hidden(ObClient *self);
 
 /*! Sends the window to the specified desktop
   @param donthide If TRUE, the window will not be shown/hidden after its

--- a/openbox/config.c
+++ b/openbox/config.c
@@ -123,6 +123,7 @@ ObAppSettings* config_create_app_settings(void)
     settings->fullscreen = -1;
     settings->max_horz = -1;
     settings->max_vert = -1;
+    settings->stop_hidden = OB_CLIENT_STOP_MODE_NONE;
     return settings;
 }
 
@@ -148,6 +149,7 @@ void config_app_settings_copy_non_defaults(const ObAppSettings *src,
     copy_if(fullscreen, -1);
     copy_if(max_horz, -1);
     copy_if(max_vert, -1);
+    copy_if(stop_hidden, OB_CLIENT_STOP_MODE_NONE);
 
     if (src->pos_given) {
         dst->pos_given = TRUE;
@@ -327,6 +329,18 @@ static void parse_single_per_app_settings(xmlNodePtr app,
     if ((n = obt_xml_find_node(app->children, "fullscreen")))
         if (!obt_xml_node_contains(n, "default"))
             settings->fullscreen = obt_xml_node_bool(n);
+
+    if ((n = obt_xml_find_node(app->children, "stop_hidden")))
+        if (!obt_xml_node_contains(n, "default")) {
+            gchar *s = obt_xml_node_string(n);
+            if (!g_ascii_strcasecmp(s, "no"))
+                settings->stop_hidden = OB_CLIENT_STOP_MODE_NONE;
+            else if (!g_ascii_strcasecmp(s, "process"))
+                settings->stop_hidden = OB_CLIENT_STOP_MODE_PROCESS;
+            else if (!g_ascii_strcasecmp(s, "group"))
+                settings->stop_hidden = OB_CLIENT_STOP_MODE_GROUP;
+            g_free(s);
+        }
 
     if ((n = obt_xml_find_node(app->children, "maximized"))) {
         if (!obt_xml_node_contains(n, "default")) {

--- a/openbox/config.h
+++ b/openbox/config.h
@@ -42,6 +42,7 @@ struct _ObAppSettings
     GPatternSpec *group_name;
     GPatternSpec *title;
     ObClientType  type;
+    ObClientStopMode stop_hidden;
 
     GravityPoint position;
     gboolean pos_given;

--- a/openbox/session.c
+++ b/openbox/session.c
@@ -603,6 +603,8 @@ static gboolean session_save_to_file(const ObSMSaveData *savedata)
                 fprintf(f, "\t<max_vert />\n");
             if (c->undecorated)
                 fprintf(f, "\t<undecorated />\n");
+            if (c->stop_hidden)
+                fprintf(f, "\t<stop_hidden />\n");
             if (savedata->focus_client == c)
                 fprintf(f, "\t<focused />\n");
             fprintf(f, "</window>\n\n");
@@ -784,6 +786,8 @@ static void session_load_file(const gchar *path)
             obt_xml_find_node(node->children, "max_vert") != NULL;
         state->undecorated =
             obt_xml_find_node(node->children, "undecorated") != NULL;
+        state->stop_hidden =
+            obt_xml_find_node(node->children, "stop_hidden") != NULL;
         state->focused =
             obt_xml_find_node(node->children, "focused") != NULL;
 

--- a/openbox/session.h
+++ b/openbox/session.h
@@ -34,7 +34,7 @@ struct _ObSessionState {
     gboolean shaded, iconic, skip_pager, skip_taskbar, fullscreen;
     gboolean above, below, max_horz, max_vert, undecorated;
     gboolean focused;
-
+    ObClientStopMode stop_hidden;
     gboolean matched;
 };
 


### PR DESCRIPTION
This option lets user to stop application processes automatically when all
the application windows are hidden from the user. A window is considered hidden
when it's iconified or shaded or does not belong to the current desktop.

This option in intended for minimization of CPU usage and power consumption.
Some modern applications (like Web browsers) tend to consume significant amount
of CPU resources even when hidden.

There are three possible values of the option:
   'no'      - do not stop application when it hides (default value)
   'process' - stop just the process the hidden window belongs to
   'group'   - stop whole process group the application belongs to; some complex
               applications (like web browsers) emerge multiple child processed,
               so in order to stop such applications it's not enough just to
               stop one process.

Example:

  <application class="Firefox">
    <stop_hidden>group</stop_hidden>
  </application>

Please note that Firefox does not create a new group for its child
processes. You need to run it via `setsid firefox` in order to have a separate
group for all Firefox processes.