### PR TITLE
Fullscreen on/off actions

### DIFF
--- a/openbox/actions/fullscreen.c
+++ b/openbox/actions/fullscreen.c
@@ -6,6 +6,8 @@ static gboolean run_func_toggle(ObActionsData *data, gpointer options);
 void action_fullscreen_startup(void)
 {
     actions_register("ToggleFullscreen", NULL, NULL, run_func_toggle);
+    actions_register("Fullscreen", NULL, NULL, run_func_on);
+    actions_register("Unfullscreen", NULL, NULL, run_func_off);
 }
 
 /* Always return FALSE because its not interactive */
@@ -14,6 +16,28 @@ static gboolean run_func_toggle(ObActionsData *data, gpointer options)
     if (data->client) {
         actions_client_move(data, TRUE);
         client_fullscreen(data->client, !data->client->fullscreen);
+        actions_client_move(data, FALSE);
+    }
+    return FALSE;
+}
+
+/* Always return FALSE because its not interactive */
+static gboolean run_func_on(ObActionsData *data, gpointer options)
+{
+    if (data->client) {
+        actions_client_move(data, TRUE);
+        client_fullscreen(data->client, TRUE);
+        actions_client_move(data, FALSE);
+    }
+    return FALSE;
+}
+
+/* Always return FALSE because its not interactive */
+static gboolean run_func_off(ObActionsData *data, gpointer options)
+{
+    if (data->client) {
+        actions_client_move(data, TRUE);
+        client_fullscreen(data->client, FALSE);
         actions_client_move(data, FALSE);
     }
     return FALSE;


### PR DESCRIPTION
ToggleFullscreen is not enough when, for example, you want to move a
window regardless of its fullscreen status.